### PR TITLE
Allow loops containing await

### DIFF
--- a/lib/no-loops.js
+++ b/lib/no-loops.js
@@ -5,11 +5,34 @@ module.exports = function (context) {
     context.report(node, 'loops are not allowed', { identifier: node.name });
   }
 
+  var loopDepth = 0
+  var isAsyncLoop = false
+
+  function enterLoop(node) {
+    if (loopDepth === 0) isAsyncLoop = false;
+  }
+
+  function exitLoop(node) {
+    if (!isAsyncLoop) {
+      reportLoopPresence(node);
+    }
+  }
+
+  function foundAwait() {
+    isAsyncLoop = true;
+  }
+
   return {
-    ForStatement: reportLoopPresence,
-    ForInStatement: reportLoopPresence,
-    WhileStatement: reportLoopPresence,
-    DoWhileStatement: reportLoopPresence,
-    ForOfStatement: reportLoopPresence
+    ForStatement: enterLoop,
+    'ForStatement:exit': exitLoop,
+    ForInStatement: enterLoop,
+    'ForInStatement:exit': exitLoop,
+    WhileStatement: enterLoop,
+    'WhileStatement:exit': exitLoop,
+    DoWhileStatement: enterLoop,
+    'DoWhileStatement:exit': exitLoop,
+    ForOfStatement: enterLoop,
+    'ForOfStatement:exit': exitLoop,
+    AwaitExpression: foundAwait
   };
 };

--- a/lib/no-loops.js
+++ b/lib/no-loops.js
@@ -5,21 +5,21 @@ module.exports = function (context) {
     context.report(node, 'loops are not allowed', { identifier: node.name });
   }
 
-  var loopDepth = 0
-  var isAsyncLoop = false
+  var awaits = []
 
-  function enterLoop(node) {
-    if (loopDepth === 0) isAsyncLoop = false;
+  function enterLoop() {
+    awaits.unshift(false)
   }
 
   function exitLoop(node) {
-    if (!isAsyncLoop) {
-      reportLoopPresence(node);
-    }
+    var await = awaits.shift()
+    if (!await) reportLoopPresence(node)
   }
 
   function foundAwait() {
-    isAsyncLoop = true;
+    for (var i = 0; i < awaits.length; i++) {
+      awaits[i] = true
+    }
   }
 
   return {

--- a/lib/no-loops.js
+++ b/lib/no-loops.js
@@ -5,20 +5,19 @@ module.exports = function (context) {
     context.report(node, 'loops are not allowed', { identifier: node.name });
   }
 
-  var awaits = []
+  var loopsContainAwait = []
 
   function enterLoop() {
-    awaits.unshift(false)
+    loopsContainAwait.unshift(false)
   }
 
   function exitLoop(node) {
-    var await = awaits.shift()
-    if (!await) reportLoopPresence(node)
+    if (!loopsContainAwait.shift()) reportLoopPresence(node)
   }
 
   function foundAwait() {
-    for (var i = 0; i < awaits.length; i++) {
-      awaits[i] = true
+    for (var i = 0; i < loopsContainAwait.length; i++) {
+      loopsContainAwait[i] = true
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/buildo/eslint-plugin-no-loops#readme",
   "devDependencies": {
-    "babel-eslint": "^6.1.0",
-    "eslint": "^2.0.0"
+    "babel-eslint": "8",
+    "eslint": "5"
   },
   "peerDependencies": {
     "eslint": ">=2.0.0"

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,11 +3,29 @@
 var rule = require('../lib/no-loops.js');
 var RuleTester = require('eslint').RuleTester;
 
-var ruleTester = new RuleTester();
+var ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
 ruleTester.run('no-loops', rule, {
   valid: [
     {
       code: '[1, 2, 3].map(function (i) { console.log(i); });'
+    },
+    {
+      code: 'async function ok() { for (var i = 0; i < n; i++) { await x[i]() } }'
+    },
+    {
+      code: 'const ok = async () => { for (const x of y) { for (const z of y) { await z() } } }'
+    },
+    {
+      code: 'async function ok() { for (const x of y) { await x() } }'
+    },
+    {
+      code: 'async function ok() { while (true) { await x() } }'
+    },
+    {
+      code: 'async function ok() { do { await x() } while (true) }'
+    },
+    {
+      code: 'const ok = async () => { for (const x of y) { for (const z in y) { await z() } } }'
     }
   ],
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -57,11 +57,6 @@ ruleTester.run('no-loops', rule, {
       errors: [ { message: 'loops are not allowed' } ]
     },
     {
-      code: 'async function bad() { while (true) { x() } }',
-      parser: 'babel-eslint',
-      errors: [ { message: 'loops are not allowed' } ]
-    },
-    {
       code: 'const ok = async () => { for (const x of y) { await x(); for (const z in y) { z() } } }',
       parser: 'babel-eslint',
       errors: [ { message: 'loops are not allowed' } ]

--- a/tests/index.js
+++ b/tests/index.js
@@ -50,6 +50,21 @@ ruleTester.run('no-loops', rule, {
       code: 'for (i of [1, 2, 3]) { console.log(i) }',
       parser: 'babel-eslint',
       errors: [ { message: 'loops are not allowed' } ]
+    },
+    {
+      code: 'async function bad() { while (true) { x() } }',
+      parser: 'babel-eslint',
+      errors: [ { message: 'loops are not allowed' } ]
+    },
+    {
+      code: 'async function bad() { while (true) { x() } }',
+      parser: 'babel-eslint',
+      errors: [ { message: 'loops are not allowed' } ]
+    },
+    {
+      code: 'const ok = async () => { for (const x of y) { await x(); for (const z in y) { z() } } }',
+      parser: 'babel-eslint',
+      errors: [ { message: 'loops are not allowed' } ]
     }
   ]
 });


### PR DESCRIPTION
Hi!

I found this plugin handy... but I don't mind loops with awaits in them, e.g.

```js
for (const foo of foos) {
  await foo()
}
```

...because this is a neat way of expressing serial execution of a list of async things (compared to say, [using reduce](https://stackoverflow.com/questions/43082934/how-to-execute-promises-sequentially-passing-the-parameters-from-an-array)).

But I'm not sure if this would warrant spawning a new plugin (e.g. `no-sync-loops`), or an option for this one. What do you think?